### PR TITLE
Fix _super to work on sealed instances

### DIFF
--- a/test/can-construct-super_test.js
+++ b/test/can-construct-super_test.js
@@ -124,3 +124,27 @@ QUnit.test("_super isn't always available (#11)", function(){
 	});
 	new Child();
 });
+
+QUnit.test("_super should work for sealed instances", function () {
+	var A = Construct.extend({
+		init: function (arg) {
+			this.arg = arg + 1;
+		},
+		add: function (num) {
+			return this.arg + num;
+		}
+	});
+	var B = A({
+		init: function (arg) {
+			this._super(arg + 2);
+		},
+		add: function (arg) {
+			console.log(this)
+			return this._super(arg + 1);
+		}
+	});
+	var b = new B(1);
+	Object.seal(b);
+	equal(b.arg, 4, 'should instantiate properly');
+	equal(b.add(2), 7, 'should call methods properly');
+});


### PR DESCRIPTION
Sealed instances can now use `_super` by assigning the super function to the instance's prototype, not directly to the instance. It still will not work if there is an instance key `_super` set, but we consider that an extreme edge case. 

Aside: Now we do not reassign to the instance unless there was actually something set on the instance's `_super` originally. Previously we were always reading `tmp = this._super` and writing `this._super = tmp`; which if tmp were never set would potentially break hidden classes (perf concern) as tmp would equal undefined.